### PR TITLE
Refined Storage Compatability: Importers, External Storage, Destructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Huge thanks to the people here for making this mod possible
 Rewrite with both code and performance optimizations and a ton of polishing
 - Contributor: [radimous](https://github.com/radimous)
 Added a ton of mod compatibility and huge technical help
+- Contributor: [iwolfking](https://github.com/iwolfking)
+Added additional support to Refined Storage and Applied Energistics, provided technical help.
 
 <details open>
 <summary style="font-size: 1.75em; font-weight: bold">
@@ -102,17 +104,19 @@ Mod Compatibilities (Click to Collapse/Expand)
 
 (Filters = List & Attribute Filters)
 
-### Modular routers
+### Modular Routers
 - Filters now work properly as filter items inside modules. Note: Only one of each filter type can be placed, but multiple attribute filters can be placed inside a single list filter.
 
-### Sophisticated backpacks
+### Sophisticated Backpacks
 - Filters now function correctly inside the filter slots of upgrades like the pickup upgrade and void upgrade.
 
-### Refined storage
+### Refined Storage
 - RS filter item compatibility: Attribute filters can now be placed inside the "Filter" item.
-- Filters work properly inside exporters.
+- Filters work properly inside Exporters, Importers, Destructors, and External Storage.
 - For performance reasons, when pulling out of a disk, only gear-like items matching the filters will be pulled out, When pulling out of items stored in external storages, everything functions normally.
-- It is recommended to not make extensive use filters with exporters to avoid possible lag.
+
+### Applied Energistics
+- Filters work properly inside of View Cells, Import Bus, Export Bus, Storage Bus, and Formation Planes. Supports normal and Fuzzy card operation.
 </details>
 
 ## Server / Client Requirements

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/MixinIWhiteListBlackList.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/MixinIWhiteListBlackList.java
@@ -1,0 +1,54 @@
+package net.joseph.vaultfilters.mixin.compat;
+
+import com.refinedmods.refinedstorage.apiimpl.API;
+import com.refinedmods.refinedstorage.blockentity.config.IWhitelistBlacklist;
+import com.simibubi.create.content.logistics.filter.FilterItem;
+import net.joseph.vaultfilters.VaultFilters;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = IWhitelistBlacklist.class, remap = false)
+public interface MixinIWhiteListBlackList {
+    /**
+     * @author iwolfking
+     * @reason Forgive me for what must be done, injects and redirects were ignored ;-;.
+     * Replaces Compararer check with Vault Filters check for FilterItems, adds support for (most) RS nodes except for exporters.
+     */
+    @Overwrite
+    public static boolean acceptsItem(IItemHandler filters, int mode, int compare, ItemStack stack) {
+        int i;
+        ItemStack slot;
+        if (mode == 0) {
+            for (i = 0; i < filters.getSlots(); ++i) {
+                slot = filters.getStackInSlot(i);
+                if(slot.getItem() instanceof FilterItem) {
+                    return VaultFilters.checkFilter(stack, slot, true, null);
+                }
+                if (API.instance().getComparer().isEqual(slot, stack, compare)) {
+                    return true;
+                }
+            }
+
+            return false;
+        } else if (mode == 1) {
+            for (i = 0; i < filters.getSlots(); ++i) {
+                slot = filters.getStackInSlot(i);
+                if(slot.getItem() instanceof FilterItem) {
+                    return !VaultFilters.checkFilter(stack, slot, true, null);
+                }
+                if (API.instance().getComparer().isEqual(slot, stack, compare)) {
+                    return false;
+                }
+            }
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/vaultfilters.mixin.json
+++ b/src/main/resources/vaultfilters.mixin.json
@@ -11,12 +11,12 @@
     "compat.MixinFuzzyPriorityList",
     "compat.MixinItemGridHandler",
     "compat.MixinItemStackHashingStrategy",
+    "compat.MixinIWhiteListBlackList",
     "compat.MixinPrecisePriorityList",
     "compat.MixinRSDiskMatcher",
     "compat.MixinRSItemMatcher",
     "compat.MixinSimpleItemMatcher",
     "compat.MixinSophItemMatcher",
-    "compat.MixinStorageExportStrategy",
     "data.EffectCloudAccessor",
     "data.EffectCloudAttributeAccessor",
     "other.MixinAttributeResearchBypass"

--- a/src/main/resources/vaultfilters.mixin.json
+++ b/src/main/resources/vaultfilters.mixin.json
@@ -17,6 +17,7 @@
     "compat.MixinRSItemMatcher",
     "compat.MixinSimpleItemMatcher",
     "compat.MixinSophItemMatcher",
+    "compat.MixinStorageExportStrategy",
     "data.EffectCloudAccessor",
     "data.EffectCloudAttributeAccessor",
     "other.MixinAttributeResearchBypass"


### PR DESCRIPTION
Joseph knows what this is already... but adds support to Refined Storage for Importers, External Storage, and Destructors. (Constructors still do not work with Vault Filters).