### PR TITLE
Fix warnings

### DIFF
--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinClientFilterItem.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinClientFilterItem.java
@@ -66,6 +66,7 @@ public abstract class MixinClientFilterItem {
     }
 
     @ModifyArg(method = "makeSummary", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z", ordinal = 0), remap = false)
+    @SuppressWarnings("unchecked") // erased generics
     private <E> E showAndAnyInListFilterTooltip(E e, @Local LocalBooleanRef blacklist,
                                              @Local(argsOnly = true) ItemStack filter) {
 

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinCreateFilteringBehaviour.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinCreateFilteringBehaviour.java
@@ -14,8 +14,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = FilteringBehaviour.class, remap = false)
 public abstract class MixinCreateFilteringBehaviour extends BlockEntityBehaviour {
-    @Shadow
-    private FilterItemStack filter;
+
+    @Shadow public abstract ItemStack getFilter();
 
     protected MixinCreateFilteringBehaviour(SmartBlockEntity be) {
         super(be);
@@ -23,7 +23,7 @@ public abstract class MixinCreateFilteringBehaviour extends BlockEntityBehaviour
 
     @Inject(method = "test(Lnet/minecraft/world/item/ItemStack;)Z", at = @At("HEAD"), cancellable = true)
     public void checkFilter(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
-        cir.setReturnValue(!isActive() || this.filter.isEmpty() || VFTests.checkFilter(stack, this.filter, true, this.blockEntity.getLevel()));
+        cir.setReturnValue(!isActive() || this.getFilter().isEmpty() || VFTests.checkFilter(stack, this.getFilter(), true, this.blockEntity.getLevel()));
     }
 
     @Shadow

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinFilterMenu.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinFilterMenu.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(FilterMenu.class)
+@Mixin(value = FilterMenu.class, remap = false)
 public class MixinFilterMenu implements FilterMenuAdvancedAccessor {
     @Shadow
     boolean respectNBT;
@@ -22,7 +22,7 @@ public class MixinFilterMenu implements FilterMenuAdvancedAccessor {
     @Unique
     boolean vf$matchAll;
 
-    @Inject(method = "initAndReadInventory(Lnet/minecraft/world/item/ItemStack;)V", at = @At("TAIL"),remap = false)
+    @Inject(method = "initAndReadInventory(Lnet/minecraft/world/item/ItemStack;)V", at = @At("TAIL"))
     public void initMatchALl(ItemStack filterItem, CallbackInfo ci, @Local CompoundTag tag) {
         vf$matchAll = tag.getBoolean("MatchAll");
     }

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinFilterScreen.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinFilterScreen.java
@@ -27,7 +27,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.Arrays;
 import java.util.List;
 
-@Mixin(FilterScreen.class)
+@Mixin(value = FilterScreen.class, remap = false)
 public abstract class MixinFilterScreen extends AbstractFilterScreen<FilterMenu> {
     @Shadow private IconButton blacklist;
     @Shadow private IconButton whitelist;
@@ -63,7 +63,7 @@ public abstract class MixinFilterScreen extends AbstractFilterScreen<FilterMenu>
     }
 
     @Inject(method = "init",at = @At(value = "INVOKE",
-            target = "Lcom/simibubi/create/content/logistics/filter/FilterScreen;handleIndicators()V",shift = At.Shift.BEFORE, ordinal = 0))
+            target = "Lcom/simibubi/create/content/logistics/filter/FilterScreen;handleIndicators()V",shift = At.Shift.BEFORE, ordinal = 0, remap = false), remap = true)
     private void injectInitializer(CallbackInfo ci, @Local(ordinal = 0) int x, @Local(ordinal = 1) int y) {
         if (!ModPresence.serverHasVaultFilters()) {
             return;
@@ -88,14 +88,14 @@ public abstract class MixinFilterScreen extends AbstractFilterScreen<FilterMenu>
         addRenderableWidgets(matchAll, matchAny, matchAllIndicator, matchAnyIndicator);
     }
 
-    @Inject(method = "getTooltipButtons", at = @At("HEAD"), cancellable = true,remap = false)
+    @Inject(method = "getTooltipButtons", at = @At("HEAD"), cancellable = true)
     private void addToolTipButtons(CallbackInfoReturnable<List<IconButton>> cir) {
         if (ModPresence.serverHasVaultFilters()) {
             cir.setReturnValue(Arrays.asList(blacklist, whitelist, respectNBT, ignoreNBT, matchAll, matchAny));
         }
     }
 
-    @Inject(method = "getTooltipDescriptions", at = @At("HEAD"), cancellable = true,remap = false)
+    @Inject(method = "getTooltipDescriptions", at = @At("HEAD"), cancellable = true)
     private void addToolTipDescriptions(CallbackInfoReturnable<List<MutableComponent>> cir) {
         if (ModPresence.serverHasVaultFilters()) {
             cir.setReturnValue(Arrays.asList(denyDESC.plainCopy(), allowDESC.plainCopy(), respectDataDESC.plainCopy(),
@@ -103,7 +103,7 @@ public abstract class MixinFilterScreen extends AbstractFilterScreen<FilterMenu>
 
         }
     }
-    @Inject(method = "getIndicators", at = @At("HEAD"), cancellable = true,remap = false)
+    @Inject(method = "getIndicators", at = @At("HEAD"), cancellable = true)
     private void addIndicators(CallbackInfoReturnable<List<Indicator>> cir) {
         if (ModPresence.serverHasVaultFilters()) {
             cir.setReturnValue(Arrays.asList(blacklistIndicator, whitelistIndicator, respectNBTIndicator,
@@ -112,7 +112,7 @@ public abstract class MixinFilterScreen extends AbstractFilterScreen<FilterMenu>
         }
     }
 
-    @Inject(method = "isButtonEnabled", at = @At("TAIL"), cancellable = true,remap = false)
+    @Inject(method = "isButtonEnabled", at = @At("TAIL"), cancellable = true)
     private void addButtonsEnabled(IconButton button, CallbackInfoReturnable<Boolean> cir) {
         if (button == matchAll) {
             cir.setReturnValue(!menuAccessor.vault_filters$getMatchAll());
@@ -121,7 +121,7 @@ public abstract class MixinFilterScreen extends AbstractFilterScreen<FilterMenu>
         }
     }
 
-    @Inject(method = "isIndicatorOn", at = @At("TAIL"), cancellable = true,remap = false)
+    @Inject(method = "isIndicatorOn", at = @At("TAIL"), cancellable = true)
     private void addIndicatorsEnabled(Indicator indicator, CallbackInfoReturnable<Boolean> cir) {
         if (indicator == matchAllIndicator) {
             cir.setReturnValue(menuAccessor.vault_filters$getMatchAll());

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinFilterScreenPacket.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinFilterScreenPacket.java
@@ -9,11 +9,12 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
-@Mixin(FilterScreenPacket.class)
+@Mixin(value = FilterScreenPacket.class, remap = false)
 public class MixinFilterScreenPacket {
     @Final @Shadow
     private FilterScreenPacket.Option option;
 
+    @SuppressWarnings("target")
     @ModifyVariable(method = "lambda$handle$0(Lnet/minecraftforge/network/NetworkEvent$Context;)V", at = @At(value = "STORE", ordinal = 0), name = "c", remap = false)
     private FilterMenu modifyFilterMenu(FilterMenu c) {
         // Modify or use the FilterMenu instance `c` here

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinListFilterItemStack.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinListFilterItemStack.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
 
-@Mixin(FilterItemStack.ListFilterItemStack.class)
+@Mixin(value = FilterItemStack.ListFilterItemStack.class, remap = false)
 public class MixinListFilterItemStack {
     @Unique
     public boolean vault_filters$isMatchAll;
@@ -30,7 +30,7 @@ public class MixinListFilterItemStack {
         vault_filters$isMatchAll = !defaults && filter.getTag().getBoolean("MatchAll");
     }
 
-    @Inject(method = "test(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;Z)Z", at = @At("HEAD"), cancellable = true, remap = false)
+    @Inject(method = "test(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;Z)Z", at = @At("HEAD"), cancellable = true)
     private void modifyTestMethod(Level world, ItemStack stack, boolean matchNBT, CallbackInfoReturnable<Boolean> cir) {
         if (this.containedItems.isEmpty()) {
             return;

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/sophisticatedcore/mixin/InventoryHandlerSlotTrackerAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/sophisticatedcore/mixin/InventoryHandlerSlotTrackerAccessor.java
@@ -6,7 +6,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.Set;
 
-@Mixin(InventoryHandlerSlotTracker.class)
+@Mixin(value = InventoryHandlerSlotTracker.class, remap = false)
 public interface InventoryHandlerSlotTrackerAccessor
 {
     @Accessor("emptySlots")

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/CardConditionAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/CardConditionAccessor.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import java.util.List;
 import java.util.Map;
 
-@Mixin(CardCondition.class)
+@Mixin(value = CardCondition.class, remap = false)
 public interface CardConditionAccessor {
     @Accessor
     Map<Integer, List<CardCondition.Filter>> getFilters();

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/CardEntryAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/CardEntryAccessor.java
@@ -2,14 +2,10 @@ package net.joseph.vaultfilters.mixin.data;
 
 import iskallia.vault.core.card.CardCondition;
 import iskallia.vault.core.card.CardEntry;
-import iskallia.vault.core.card.CardScaler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-import java.util.List;
-import java.util.Map;
-
-@Mixin(CardEntry.class)
+@Mixin(value = CardEntry.class, remap = false)
 public interface CardEntryAccessor {
     @Accessor
     CardCondition getCondition();

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/CardScaleAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/CardScaleAccessor.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import java.util.List;
 import java.util.Map;
 
-@Mixin(CardScaler.class)
+@Mixin(value = CardScaler.class, remap = false)
 public interface CardScaleAccessor {
     @Accessor
     Map<Integer, List<CardScaler.Filter>> getFilters();

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/ConditionFilterAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/ConditionFilterAccessor.java
@@ -3,13 +3,12 @@ package net.joseph.vaultfilters.mixin.data;
 import iskallia.vault.core.card.CardCondition;
 import iskallia.vault.core.card.CardEntry;
 import iskallia.vault.core.card.CardNeighborType;
-import iskallia.vault.core.card.CardScaler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.Set;
 
-@Mixin(CardCondition.Filter.class)
+@Mixin(value = CardCondition.Filter.class, remap = false)
 public interface ConditionFilterAccessor {
     @Accessor
     Set<CardNeighborType> getNeighborFilter();

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/EffectCloudAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/EffectCloudAccessor.java
@@ -4,7 +4,7 @@ import iskallia.vault.gear.attribute.custom.effect.EffectCloudAttribute;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(EffectCloudAttribute.EffectCloud.class)
+@Mixin(value = EffectCloudAttribute.EffectCloud.class, remap = false)
 public interface EffectCloudAccessor {
     @Accessor
     String getTooltip();

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/EffectCloudAttributeAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/EffectCloudAttributeAccessor.java
@@ -4,7 +4,7 @@ import iskallia.vault.gear.attribute.custom.effect.EffectCloudAttribute;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(EffectCloudAttribute.class)
+@Mixin(value = EffectCloudAttribute.class, remap = false)
 public interface EffectCloudAttributeAccessor {
     @Accessor
     EffectCloudAttribute.EffectCloud getEffectCloud();

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/GearCardModifierAccesor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/GearCardModifierAccesor.java
@@ -1,15 +1,12 @@
 package net.joseph.vaultfilters.mixin.data;
 
-import iskallia.vault.core.card.CardCondition;
-import iskallia.vault.core.card.CardEntry;
 import iskallia.vault.core.card.GearCardModifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Mixin(GearCardModifier.class)
+@Mixin(value = GearCardModifier.class, remap = false)
 public interface GearCardModifierAccesor {
     @Accessor
     <T> Map<Integer, T> getValues();

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/LootCardModifierConfigAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/LootCardModifierConfigAccessor.java
@@ -5,7 +5,7 @@ import iskallia.vault.core.world.loot.LootPool;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-@Mixin(TaskLootCardModifier.Config.class)
+@Mixin(value = TaskLootCardModifier.Config.class, remap = false)
 public interface LootCardModifierConfigAccessor {
     @Accessor
     LootPool getLoot();

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/ScalerFilterAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/ScalerFilterAccessor.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.Set;
 
-@Mixin(CardScaler.Filter.class)
+@Mixin(value = CardScaler.Filter.class, remap = false)
 public interface ScalerFilterAccessor {
     @Accessor
     Set<CardNeighborType> getNeighborFilter();

--- a/src/main/java/net/joseph/vaultfilters/mixin/data/TaskLootCardModifierAccessor.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/data/TaskLootCardModifierAccessor.java
@@ -1,13 +1,12 @@
 package net.joseph.vaultfilters.mixin.data;
 
 import iskallia.vault.core.card.TaskLootCardModifier;
-import iskallia.vault.core.world.loot.LootPool;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 import java.util.Map;
 
-@Mixin(TaskLootCardModifier.class)
+@Mixin(value = TaskLootCardModifier.class, remap = false)
 public interface TaskLootCardModifierAccessor {
     @Accessor
     Map<Integer, Integer> getCounts();


### PR DESCRIPTION
most warnings are fixed by specifying correct remap values
2 are supressed
- MixinFilterScreenPacket - mixin ap trips up on lambda methods (private synthetic)
- MixinClientFilterItem - unchecked cast (erased generic info)