### PR TITLE
Add Laser IO compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,7 @@ dependencies {
     implementation fg.deobf("curse.maven:sophisticated-backpacks-422301:4637292")
     implementation fg.deobf("curse.maven:storage-drawers-223852:3807626")
     implementation fg.deobf("curse.maven:toms-storage-378609:5211203")
+    implementation "curse.maven:laserio-626839:5730007"
     implementation fg.deobf("curse.maven:vault-hunters-official-mod-458203:6644290")
     compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.3.6"))
     implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.3.6")) {

--- a/src/main/java/net/joseph/vaultfilters/configs/VFServerConfig.java
+++ b/src/main/java/net/joseph/vaultfilters/configs/VFServerConfig.java
@@ -13,6 +13,7 @@ public class VFServerConfig {
     public static final ForgeConfigSpec.ConfigValue<Boolean> BACKPACKS_COMPAT;
     public static final ForgeConfigSpec.ConfigValue<Boolean> AE2_COMPAT;
     public static final ForgeConfigSpec.ConfigValue<Boolean> TOMS_COMPAT;
+    public static final ForgeConfigSpec.ConfigValue<Boolean> LASERIO_COMPAT;
     public static final ForgeConfigSpec.ConfigValue<Boolean> CACHE_DATAFIX;
 
     static {
@@ -37,6 +38,9 @@ public class VFServerConfig {
 
         TOMS_COMPAT = BUILDER.comment("\nEnable compatibility for list and attribute filters inside Tom's filtered inventory connector" +
                 "\nDefault:true").define("Tom's Simple Storage Compatibility", true);
+
+        LASERIO_COMPAT = BUILDER.comment("\nEnable compatibility for list and attribute filters inside LaserIO's card filters" +
+                "\nDefault:true").define("LaserIO Compatibility", true);
 
         CACHE_DATAFIX = BUILDER.comment("\nDelete old cache entries from items when they're filtered through" +
                 "\nDefault:false").define("Old cache data fixer", false);

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/laserio/LaserIOMixinPlugin.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/laserio/LaserIOMixinPlugin.java
@@ -1,0 +1,11 @@
+package net.joseph.vaultfilters.mixin.compat.laserio;
+
+import net.joseph.vaultfilters.configs.MixinConfig;
+import net.minecraftforge.fml.loading.LoadingModList;
+
+public class LaserIOMixinPlugin extends MixinConfig {
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return LoadingModList.get().getModFileById("laserio") != null;
+    }
+}

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/laserio/mixin/MixinBaseCardCache.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/laserio/mixin/MixinBaseCardCache.java
@@ -1,0 +1,70 @@
+package net.joseph.vaultfilters.mixin.compat.laserio.mixin;
+
+import com.direwolf20.laserio.common.items.filters.FilterMod;
+import com.direwolf20.laserio.common.items.filters.FilterNBT;
+import com.direwolf20.laserio.common.items.filters.FilterTag;
+import com.direwolf20.laserio.util.BaseCardCache;
+import com.direwolf20.laserio.util.ItemStackKey;
+import com.simibubi.create.content.logistics.filter.FilterItem;
+import net.joseph.vaultfilters.VFTests;
+import net.joseph.vaultfilters.configs.VFServerConfig;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+import java.util.Map;
+
+
+@Mixin(value = BaseCardCache.class, remap = false)
+public class MixinBaseCardCache {
+
+    @Shadow @Final public List<ItemStack> filteredItems;
+
+    @Shadow @Final public ItemStack filterCard;
+
+    @Shadow @Final public Map<ItemStackKey, Boolean> filterCache;
+
+    @Shadow @Final public boolean isCompareNBT;
+
+    @Shadow @Final public boolean isAllowList;
+
+    @Inject(method = "isStackValidForCard(Lnet/minecraft/world/item/ItemStack;)Z", at = @At("HEAD"), remap = false, cancellable = true)
+    private void checkCreateFilterForCard(ItemStack testStack, CallbackInfoReturnable<Boolean> cir) {
+        if(!VFServerConfig.LASERIO_COMPAT.get()) {
+            return;
+        }
+
+        if(this.filterCard.isEmpty()) {
+            cir.setReturnValue(true);
+        }
+
+        //Ignore non-basic Filter Cards
+        if(!(this.filterCard.getItem() instanceof FilterMod || this.filterCard.getItem() instanceof FilterTag || this.filterCard.getItem() instanceof FilterNBT)) {
+            ItemStackKey key = new ItemStackKey(testStack, this.isCompareNBT);
+
+            if (this.filterCache.containsKey(key)) {
+                cir.setReturnValue(this.filterCache.get(key));
+            }
+
+            for(ItemStack stack : this.filteredItems) {
+                if(stack.getItem() instanceof FilterItem) {
+                    if(VFTests.checkFilter(key.getStack(), stack, true, null)) {
+                        this.filterCache.put(key, this.isAllowList);
+                        cir.setReturnValue(this.isAllowList);
+                    }
+                    else {
+                        if (key.equals(new ItemStackKey(stack, this.isCompareNBT))) {
+                            this.filterCache.put(key, this.isAllowList);
+                            cir.setReturnValue(this.isAllowList);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/mixins.vaultfilters.core.json
+++ b/src/main/resources/mixins.vaultfilters.core.json
@@ -3,15 +3,15 @@
   "package": "net.joseph.vaultfilters.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "data.EffectCloudAccessor",
-    "data.EffectCloudAttributeAccessor",
-    "data.CardEntryAccessor",
     "data.CardConditionAccessor",
-    "data.ScalerFilterAccessor",
+    "data.CardEntryAccessor",
     "data.CardScaleAccessor",
     "data.ConditionFilterAccessor",
+    "data.EffectCloudAccessor",
+    "data.EffectCloudAttributeAccessor",
     "data.GearCardModifierAccesor",
     "data.LootCardModifierConfigAccessor",
+    "data.ScalerFilterAccessor",
     "data.TaskLootCardModifierAccessor",
     "other.MixinAttributeResearchBypass"
   ],
@@ -19,5 +19,5 @@
     "defaultRequire": 1
   },
   "refmap": "mixins.vaultfilters.refmap.json",
-  "minVersion" : "0.8"
+  "minVersion": "0.8"
 }

--- a/src/main/resources/mixins.vaultfilters.laserio.json
+++ b/src/main/resources/mixins.vaultfilters.laserio.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "net.joseph.vaultfilters.mixin.compat.laserio.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "plugin": "net.joseph.vaultfilters.mixin.compat.laserio.LaserIOMixinPlugin",
+  "mixins": [
+    "MixinBaseCardCache"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "refmap": "mixins.vaultfilters.refmap.json",
+  "minVersion" : "0.8"
+}


### PR DESCRIPTION
Backports the LaserIO compatability from Create: Filters Anywhere into Vault Filters