### PR TITLE
add deck core attributes

### DIFF
--- a/src/main/java/net/joseph/vaultfilters/VaultFilters.java
+++ b/src/main/java/net/joseph/vaultfilters/VaultFilters.java
@@ -13,6 +13,8 @@ import net.joseph.vaultfilters.attributes.companion.items.CompanionRelicAttribut
 import net.joseph.vaultfilters.attributes.companion.items.CompanionTrailAttribute;
 import net.joseph.vaultfilters.attributes.deck.CardDeckHasModifierAttribute;
 import net.joseph.vaultfilters.attributes.deck.CardDeckTypeAttribute;
+import net.joseph.vaultfilters.attributes.deck_core.DeckCoreTypeAttribute;
+import net.joseph.vaultfilters.attributes.deck_core.DeckCoreValueAttribute;
 import net.joseph.vaultfilters.attributes.focus.FacetedFocusTypeAttribute;
 import net.joseph.vaultfilters.attributes.inner.InnerCardPackAttribute;
 import net.joseph.vaultfilters.attributes.inner.InnerJewelPouchAttribute;
@@ -243,6 +245,10 @@ public class VaultFilters {
         //Deck
         new CardDeckHasModifierAttribute(true).register(CardDeckHasModifierAttribute::new);
         new CardDeckTypeAttribute("").register(CardDeckTypeAttribute::new);
+
+        //Deck Core
+        new DeckCoreTypeAttribute("steadfast").register(DeckCoreTypeAttribute::new);
+        new DeckCoreValueAttribute(0.5f).register(DeckCoreValueAttribute::new);
 
         //Temporal Relic
         new TemporalRelicModifierAttribute("").register(TemporalRelicModifierAttribute::new);

--- a/src/main/java/net/joseph/vaultfilters/attributes/abstracts/FloatAttribute.java
+++ b/src/main/java/net/joseph/vaultfilters/attributes/abstracts/FloatAttribute.java
@@ -1,0 +1,58 @@
+package net.joseph.vaultfilters.attributes.abstracts;
+
+import com.simibubi.create.content.logistics.filter.ItemAttribute;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public abstract class FloatAttribute extends VaultAttribute<Float> {
+    private static final Map<Class<?>, Function<Float, FloatAttribute>> factories = new HashMap<>();
+
+    protected FloatAttribute(Float value) {
+        super(value);
+    }
+
+    public void register(Function<Float, FloatAttribute> factory) {
+        factories.put(getClass(), factory);
+        super.register();
+    }
+
+    protected abstract IntAttribute.NumComparator getComparator();
+
+    @Override
+    public boolean appliesTo(ItemStack itemStack) {
+        final Float value = getValue(itemStack);
+        if (value == null) {
+            return false;
+        }
+        if (this.getComparator() == IntAttribute.NumComparator.AT_LEAST) {
+            return value >= this.value;
+        }
+        if (this.getComparator() == IntAttribute.NumComparator.AT_MOST) {
+            return value <= this.value;
+        }
+        if (this.getComparator() == IntAttribute.NumComparator.EQUAL) {
+            return value.equals(this.value);
+        }
+
+        return value >= this.value;
+    }
+
+    @Override
+    public FloatAttribute withValue(Float value) {
+        return factories.getOrDefault(getClass(), ignored -> null).apply(value);
+    }
+
+    @Override
+    public void writeNBT(CompoundTag compoundTag) {
+        compoundTag.putFloat(getNBTKey(), this.value);
+    }
+
+    @Override
+    public ItemAttribute readNBT(CompoundTag compoundTag) {
+        return withValue(compoundTag.getFloat(getNBTKey()));
+    }
+}

--- a/src/main/java/net/joseph/vaultfilters/attributes/deck_core/DeckCoreTypeAttribute.java
+++ b/src/main/java/net/joseph/vaultfilters/attributes/deck_core/DeckCoreTypeAttribute.java
@@ -1,0 +1,31 @@
+package net.joseph.vaultfilters.attributes.deck_core;
+
+import iskallia.vault.core.card.modifier.deck.DeckModifier;
+import iskallia.vault.init.ModConfigs;
+import iskallia.vault.item.DeckSocketItem;
+import net.joseph.vaultfilters.attributes.abstracts.StringAttribute;
+import net.minecraft.world.item.ItemStack;
+
+
+public class DeckCoreTypeAttribute extends StringAttribute {
+    public DeckCoreTypeAttribute(String value) {
+        super(value);
+    }
+
+    @Override
+    public String getValue(ItemStack itemStack) {
+        var deckModifier = DeckSocketItem.getDeckModifier(itemStack).orElse(null);
+        if (deckModifier == null) return null;
+        return deckModifier.getId();
+    }
+
+    @Override
+    public Object[] getTranslationParameters() {
+        return new Object[]{ModConfigs.DECK_MODIFIERS.getById(this.value).map(DeckModifier::getName).orElse(this.value)};
+    }
+
+    @Override
+    public String getNBTKey() {
+        return "deck_core_type";
+    }
+}

--- a/src/main/java/net/joseph/vaultfilters/attributes/deck_core/DeckCoreValueAttribute.java
+++ b/src/main/java/net/joseph/vaultfilters/attributes/deck_core/DeckCoreValueAttribute.java
@@ -1,0 +1,48 @@
+package net.joseph.vaultfilters.attributes.deck_core;
+
+import iskallia.vault.item.DeckSocketItem;
+import net.joseph.vaultfilters.attributes.abstracts.FloatAttribute;
+import net.joseph.vaultfilters.attributes.abstracts.IntAttribute;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ ✅ Azure        	All Blue cards will be X% more efficient<br>
+ ✅ Crimson 	    All Red cards will be X% more efficient<br>
+ ✅ Viridian 	    All Green cards will be X% more efficient<br>
+ ✅ Golden 	        All Yellow cards will be X% more efficient<br>
+ ✅ Equilibrium 	+X% Stat card efficiency per unique deck colour<br>
+ ✅ Shiny 	        All Foil cards will be X% more efficient<br>
+ ✅ Steadfast 	    All Stat cards will be X% more efficient<br>
+ ✅ Harvest 	    -X% Resource card requirements<br>
+ ✅ Fortune 	    +X% chance for Resource cards to double rewards<br>
+ <br>
+ ⚠️ Empyreal 	    ✅ +X efficiency for ❌ NUMBER ❌ TYPE cards {@link iskallia.vault.core.card.modifier.deck.SlotDeckModifier}<br>
+ ❌ Bounty 	        ❌ +X Crate Tier when completing a vault with at least ❌ X Resource Card(s) {@link iskallia.vault.core.card.modifier.deck.BountyDeckModifier}<br>
+ */
+public class DeckCoreValueAttribute extends FloatAttribute {
+    public DeckCoreValueAttribute(Float value) {
+        super(value);
+    }
+
+    @Override
+    public IntAttribute.NumComparator getComparator() {
+        return IntAttribute.NumComparator.AT_LEAST;
+    }
+
+    @Override
+    public Float getValue(ItemStack itemStack) {
+        var deckModifier = DeckSocketItem.getDeckModifier(itemStack).orElse(null);
+        if (deckModifier == null) return null;
+        return deckModifier.getModifierValue();
+    }
+
+    @Override public Object[] getTranslationParameters() {
+        return new Object[] {String.format("%.2f%%", value * 100)};
+    }
+
+    @Override
+    public String getNBTKey() {
+        return "deck_core_value";
+    }
+
+}

--- a/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinAttributeFilterMenu.java
+++ b/src/main/java/net/joseph/vaultfilters/mixin/compat/create/MixinAttributeFilterMenu.java
@@ -1,9 +1,11 @@
 package net.joseph.vaultfilters.mixin.compat.create;
 
-import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.simibubi.create.content.logistics.filter.AbstractFilterMenu;
 import com.simibubi.create.content.logistics.filter.AttributeFilterMenu;
-import com.simibubi.create.content.logistics.filter.FilterMenu;
+import com.simibubi.create.content.logistics.filter.ItemAttribute;
+import com.simibubi.create.foundation.utility.Pair;
 import net.joseph.vaultfilters.access.AbstractFilterMenuAdvancedAccessor;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -13,6 +15,8 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
 
 @Mixin(value = AttributeFilterMenu.class, remap = false)
 public class MixinAttributeFilterMenu {
@@ -56,6 +60,24 @@ public class MixinAttributeFilterMenu {
     @Inject(method = "initAndReadInventory(Lnet/minecraft/world/item/ItemStack;)V", at = @At(value = "TAIL"),remap = false)
     private void initName(ItemStack filterItem, CallbackInfo ci) {
         AttributeFilterMenu instance = (AttributeFilterMenu) (Object) (this);
-        ((AbstractFilterMenuAdvancedAccessor) (AbstractFilterMenu) instance).vault_filters$setName(filterItem.getHoverName().getString());
+        ((AbstractFilterMenuAdvancedAccessor) instance).vault_filters$setName(filterItem.getHoverName().getString());
+    }
+
+    // Fixes crash when client connects with new attributes
+    @WrapOperation(method = "lambda$initAndReadInventory$0", at = @At(value = "INVOKE", target = "Ljava/util/List;add(Ljava/lang/Object;)Z"),remap = false)
+    private boolean addNullCheck(List<Pair<ItemAttribute, Boolean>> instance, Object e, Operation<Boolean> original) {
+        @SuppressWarnings("unchecked") // generics
+        var pair = (Pair<ItemAttribute, Boolean>) e;
+        if (pair.getFirst() == null) {
+            return false;
+        }
+        return original.call(instance, e);
+    }
+
+    @Inject(method = "appendSelectedAttribute", at = @At(value = "HEAD"),remap = false, cancellable = true)
+    private void addNullCheck(ItemAttribute itemAttribute, boolean inverted, CallbackInfo ci) {
+        if (itemAttribute == null) {
+            ci.cancel();
+        }
     }
 }

--- a/src/main/resources/assets/vaultfilters/lang/en_us.json
+++ b/src/main/resources/assets/vaultfilters/lang/en_us.json
@@ -310,6 +310,12 @@
   "create.item_attributes.card_deck_type": "is a \"%1$s\"",
   "create.item_attributes.card_deck_type.inverted": "isn't a \"%1$s\"",
 
+  "create.item_attributes.deck_core_type": "is a \"%1$s\"",
+  "create.item_attributes.deck_core_type.inverted": "isn't a \"%1$s\"",
+
+  "create.item_attributes.deck_core_value": "is a deck core with at least \"%1$s\" value",
+  "create.item_attributes.deck_core_value.inverted": "isn't a deck core with at least \"%1$s\" value",
+
   "create.item_attributes.companion_cooldown": "is a Companion on cooldown",
   "create.item_attributes.companion_cooldown.inverted": "isn't a Companion on cooldown",
 


### PR DESCRIPTION
added checks to prevent crashes when client connects with attributes unknown to the server
it now doesn't save the new attribute in the filter instead of crashing the server

deck type attribute works for all types
the deck value has only support for some attributes

- [x] **Azure** - All Blue cards will be X% more efficient  
- [x] **Crimson** - All Red cards will be X% more efficient  
- [x] **Viridian** - All Green cards will be X% more efficient  
- [x] **Golden** - All Yellow cards will be X% more efficient  
- [x] **Equilibrium** - +X% Stat card efficiency per unique deck colour  
- [x] **Shiny** - All Foil cards will be X% more efficient  
- [x] **Steadfast** - All Stat cards will be X% more efficient  
- [x] **Harvest** - -X% Resource card requirements  
- [x] **Fortune** - +X% chance for Resource cards to double rewards  

- [ ]  **Empyreal** - ✅+X efficiency for ❌ NUMBER ❌ TYPE cards  
- [ ]  **Bounty** - ❌+X Crate Tier when completing a vault with at least ❌ X Resource Card(s)

wv26 cores are untested